### PR TITLE
v1.2 Alternate deadlock fix

### DIFF
--- a/asm/symbols.asm
+++ b/asm/symbols.asm
@@ -244,7 +244,7 @@
 .definelabel preventSongPlaying, 0x80745650
 .definelabel getTrackChannel, 0x8060245C
 .definelabel songData, 0x80745658
-.definelabel nullArray, 0x80745924
+.definelabel trackStateArray, 0x80745924
 
 .definelabel initDisplayList, 0x807132DC
 .definelabel displayImage, 0x8068C5A8

--- a/asm/symbols.asm
+++ b/asm/symbols.asm
@@ -242,6 +242,9 @@
 .definelabel textOverlayCode, 0x8069DA54
 .definelabel initiateTransitionFade, 0x807124B8
 .definelabel preventSongPlaying, 0x80745650
+.definelabel getTrackChannel, 0x8060245C
+.definelabel songData, 0x80745658
+.definelabel nullArray, 0x80745924
 
 .definelabel initDisplayList, 0x807132DC
 .definelabel displayImage, 0x8068C5A8

--- a/include/vanilla_defs.h
+++ b/include/vanilla_defs.h
@@ -73,6 +73,7 @@ extern void cseqpFreeVoice(ALCSPlayer* player, ALVoice* voice);
 extern void unkSynthFunction(int curSamples, char unkChar, int effectsBus, int* unkInt);
 
 extern int samplesTilNextCallback(void* player);
+extern int getTrackChannel(int song);
 
 // Vanilla data
 extern f32 TransitionSpeed;
@@ -161,6 +162,8 @@ extern f32 LZFadeoutProgress;
 extern hudData* HUD;
 
 extern s8 preventSongPlaying;
+extern u16 songData[176];
+extern u16 nullArray[12];
 extern ALCSPlayer* SeqPlayers[4];
 extern u8 SongInWriteSlot[4];
 extern s16 MusicTrackChannels[12];

--- a/include/vanilla_defs.h
+++ b/include/vanilla_defs.h
@@ -163,7 +163,7 @@ extern hudData* HUD;
 
 extern s8 preventSongPlaying;
 extern u16 songData[176];
-extern u16 nullArray[12];
+extern u16 trackStateArray[12];
 extern ALCSPlayer* SeqPlayers[4];
 extern u8 SongInWriteSlot[4];
 extern s16 MusicTrackChannels[12];

--- a/src/init.c
+++ b/src/init.c
@@ -98,3 +98,9 @@ void quickInit(void) {
     *(s8*)(0x80745D20) = 1;
     // *(s8*)(0x80745D20) = 0;
 }
+
+assignAllSongsToBank0(){
+    for(int i = 0; i < 176; i++){
+        songData[i] &= 0xFFF9;
+    }
+}

--- a/src/init.c
+++ b/src/init.c
@@ -15,6 +15,7 @@ void initHack(void) {
         *(s32 *)(0x80731F78) = 0;
         *(int*)(0x8076BF38) = (int)&music_storage[0]; // Increase music storage
         initStackTrace();
+        assignAllSongsToBank0();
         loadSingularHook(0x8071417C, &displayListCode);
         writeFunction(0x80602A2C, &preventSongRestartDeadlock);
         *(int*)(0x80602A30) = 0x30E500FF; // _ANDI $a1, $a3, 0xFF (vanilla code for that location)
@@ -101,6 +102,6 @@ void quickInit(void) {
 
 assignAllSongsToBank0(){
     for(int i = 0; i < 176; i++){
-        songData[i] &= 0xFFF9;
+        songData[i] &= 0xFF81;
     }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1,8 +1,6 @@
 #include "../include/common.h"
 
 static s8 has_loaded = 0;
-static u16 previously_restarted_song = 0;
-static u8 force_restart = 0; // forces the song to restart, despite it being told not to restart a song that's already playing
 
 void cFuncLoop(void) {
 	/*
@@ -39,16 +37,10 @@ Gfx* displayListModifiers(Gfx* dl) {
     return dl;
 }
 
-// Prevent handleMusic2 from making needlessly(?) restarting the song before it even had a chance to play
+// Prevent handleMusic2 from needlessly(?) restarting the song before it even had a chance to play
 void preventSongRestartDeadlock(int write_slot, int song, float volume){
 	if (nullArray[getTrackChannel(song)] != 1){
-		previously_restarted_song = MusicTrackChannels[0];
 		restartSong(write_slot, song, volume);
 	}
 	resetMaxMetrics();
-}
-
-// This was the first solution I found when trying to make a global accessible in a different file
-void forceRestart(){
-	force_restart = 1;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -41,10 +41,9 @@ Gfx* displayListModifiers(Gfx* dl) {
 
 // Prevent handleMusic2 from making needlessly(?) restarting the song before it even had a chance to play
 void preventSongRestartDeadlock(int write_slot, int song, float volume){
-	if (MusicTrackChannels[write_slot] != previously_restarted_song || force_restart){
+	if (nullArray[getTrackChannel(song)] != 1){
 		previously_restarted_song = MusicTrackChannels[0];
 		restartSong(write_slot, song, volume);
-		force_restart = 0;
 	}
 	resetMaxMetrics();
 }

--- a/src/main.c
+++ b/src/main.c
@@ -39,7 +39,7 @@ Gfx* displayListModifiers(Gfx* dl) {
 
 // Prevent handleMusic2 from needlessly(?) restarting the song before it even had a chance to play
 void preventSongRestartDeadlock(int write_slot, int song, float volume){
-	if (nullArray[getTrackChannel(song)] != 1){
+	if (trackStateArray[getTrackChannel(song)] != 1){
 		restartSong(write_slot, song, volume);
 	}
 	resetMaxMetrics();

--- a/src/menu.c
+++ b/src/menu.c
@@ -247,9 +247,12 @@ void playNewSong(int index) {
     for (int i = 0; i < 4; i++) {
         SongInWriteSlot[i] = 0;
     }
+    for (int i = 0; i < 12; i++) {
+        nullArray[i] = 0;
+    }
     preventSongPlaying = 1;
     MusicTrackChannels[0] = index; // This is an incredibly incredibly dirty way to do it, but it yields better load times
-    forceRestart(); // Circumvent the deadlock-prevention one (1) time. 
+    // forceRestart(); // Circumvent the deadlock-prevention one (1) time. 
     playing_index = index;
     paused = 0;
 }

--- a/src/menu.c
+++ b/src/menu.c
@@ -252,7 +252,6 @@ void playNewSong(int index) {
     }
     preventSongPlaying = 1;
     MusicTrackChannels[0] = index; // This is an incredibly incredibly dirty way to do it, but it yields better load times
-    // forceRestart(); // Circumvent the deadlock-prevention one (1) time. 
     playing_index = index;
     paused = 0;
 }

--- a/src/menu.c
+++ b/src/menu.c
@@ -248,7 +248,7 @@ void playNewSong(int index) {
         SongInWriteSlot[i] = 0;
     }
     for (int i = 0; i < 12; i++) {
-        nullArray[i] = 0;
+        trackStateArray[i] = 0;
     }
     preventSongPlaying = 1;
     MusicTrackChannels[0] = index; // This is an incredibly incredibly dirty way to do it, but it yields better load times

--- a/src/menu.c
+++ b/src/menu.c
@@ -503,7 +503,7 @@ Gfx* displayMusicMenu(Gfx* dl) {
     dl = renderMenuOption(dl, zip_states[zip_in_progress], MENUOP_ZIP, 170, CONTROLS_Y + 80);
     
     dk_strFormat(voices_in_use_str, "VOICES: %s OF 44 WIP", padNumber(getVoicesUsed(), 2));
-    dk_strFormat(events_in_queue_str, "EVENT QUEUE: %s OF 64 WIP", padNumber(getEventsUsed(), 2));
+    // dk_strFormat(events_in_queue_str, "EVENT QUEUE: %s OF 64 WIP", padNumber(getEventsUsed(), 2));  // Stability; Can keep increasing far beyond 800
     // dk_strFormat(updates_in_use_str, "UPDATES: %s OF 112", padNumber(getUpdatesUsed(), 3));
 
     // Metrics
@@ -514,6 +514,6 @@ Gfx* displayMusicMenu(Gfx* dl) {
     // Credits
     dl = drawPixelTextContainer(dl, 20, 208, "HACK BY BALLAAM AND ALMOSTSEAGULL", 0x0D, 0x3B, 0x4F, 0xFF, 0);
     dl = drawPixelTextContainer(dl, 20, 220, "DISCORD.DK64RANDOMIZER.COM", 0x0D, 0x3B, 0x4F, 0xFF, 0);
-    dl = drawPixelTextContainer(dl, 253, 220, "V1.1", 0x08, 0x77, 0xA6, 0xFF, 0);
+    dl = drawPixelTextContainer(dl, 253, 220, "V1.2", 0x08, 0x77, 0xA6, 0xFF, 0);
     return dl;
 }


### PR DESCRIPTION
- Fixed a crash where it tries to put a large song into a small storage bank.
- Improved the fix that ensures that songs don't take too long to start playing.
- Disabled "events used" metric for the time being. It was inaccurate, and in a specific case just keeps increasing.